### PR TITLE
feat(fsdp2): eliminate backward all-gather in ZeRO-2 mode for 21% thr…

### DIFF
--- a/lingbotvla/distributed/torch_parallelize.py
+++ b/lingbotvla/distributed/torch_parallelize.py
@@ -454,6 +454,12 @@ def build_parallelize_model(
                 if layer.__class__.__name__ == "Qwen2_5_VLDecoderLayer" or layer.__class__.__name__ == "Qwen2_5_VLVisionBlock":
                     logger.info_rank0(f"Apply FSDP2 to {layer.__class__.__name__}.")
                     fully_shard(layer, **mp_fsdp_kwargs)
+
+            # Eliminate backward all-gather by disabling reshard_after_backward.
+            if not enable_full_shard and hasattr(model, "set_reshard_after_backward"):
+                model.set_reshard_after_backward(False, recurse=True)
+                logger.info_rank0("FSDP2: set_reshard_after_backward(False) applied to eliminate backward all-gather.")
+
         elif parallel_state.dp_mode == "fsdp1":
             wrap_policy = partial(
                 lambda_auto_wrap_policy, lambda_fn=lambda module: module.__class__.__name__ in basic_modules

--- a/tasks/vla/train_lingbotvla.py
+++ b/tasks/vla/train_lingbotvla.py
@@ -381,11 +381,28 @@ def main():
             if args.train.data_parallel_mode == "fsdp1":
                 grad_norm = model.clip_grad_norm_(max_grad_norm).item()
             else:
-                grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, foreach=True)
+                # Use optimizer param_groups to get the sharded DTensor params.
+                # When reshard_after_backward=False, model.parameters() returns
+                # unsharded params whose .grad is None after reduce-scatter.
+                all_params = [p for group in optimizer.param_groups for p in group['params']]
+                grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_grad_norm, foreach=True)
 
             optimizer.step()
             lr_scheduler.step()
             optimizer.zero_grad()
+
+            # Solution A: With reshard_after_backward=False, parameters remain
+            # unsharded after backward. The optimizer updates the sharded DTensor,
+            # but FSDP2's unshard() early-returns if params are already unsharded,
+            # causing the next forward to use the stale unsharded copy.
+            # Manually reshard all FSDP2 modules so the next forward triggers
+            # an all-gather of the freshly updated parameters.
+            # Only needed when enable_full_shard=False (ZeRO-2 mode).
+            if args.train.data_parallel_mode == "fsdp2" and not args.train.enable_full_shard:
+                from torch.distributed.fsdp import FSDPModule
+                for module in model.modules():
+                    if isinstance(module, FSDPModule):
+                        module.reshard()
             if hasattr(grad_norm, "full_tensor"):
                 grad_norm = grad_norm.full_tensor().item()
 


### PR DESCRIPTION
## Summary

- Eliminate redundant backward all-gather communications in FSDP2 ZeRO-2 mode (`enable_full_shard=False`) by disabling `reshard_after_backward`
- Fix broken gradient clipping caused by parameter lifecycle changes — switch to optimizer `param_groups` for accessing sharded DTensor parameters
- Manually reshard all FSDP2 modules after optimizer step to ensure the next forward pass all-gathers the freshly updated weights

## Background

When using `enable_full_shard: false` (i.e., `reshard_after_forward=False`) with `enable_gradient_checkpointing: true`, profiler analysis revealed massive redundant all-gather operations during backward, caused by:

1. FSDP2's `_post_backward` hook unconditionally calls `reshard()` (not controlled by `reshard_after_forward`)
2. Gradient checkpointing triggers forward recomputation during backward → detects params as SHARDED → issues another all-gather
3. This creates a "reshard → recompute forward unshard" loop, generating excessive unnecessary communication

## Changes

### 1. `lingbotvla/distributed/torch_parallelize.py`

After all `fully_shard()` calls complete, when `enable_full_shard=False`:

```python
model.set_reshard_after_backward(False, recurse=True)
```

Keeps parameters unsharded throughout backward, eliminating all-gathers triggered by gradient checkpointing recomputation.

### 2. `tasks/vla/train_lingbotvla.py`

**Gradient clipping fix**: With `reshard_after_backward=False`, `model.parameters()` returns unsharded params whose `.grad` is None. Fixed by collecting sharded DTensor params from `optimizer.param_groups` instead.

**Manual reshard**: After optimizer step, iterate all FSDPModules and call `module.reshard()` to force parameters back to SHARDED state, ensuring the next forward triggers an all-gather of the updated weights. Without this, FSDP2's `unshard()` early-returns when params are already unsharded, causing forward to use stale parameter copies and loss to stop converging.

## Performance Results

### Per-Step Communication Breakdown

| Operator | Before | After | Reduction | Improvement |
|----------|--------|-------|-----------|-------------|
| AllGather (×292→×148) | 1333.479 ms | 406.298 ms | -927.182 ms | **-69.53%** |
| ReduceScatter (×146→×146) | 650.945 ms | 640.236 ms | -10.709 ms | -1.65% |
| AllReduce (×3→×3) | 0.116 ms | 0.572 ms | +0.455 ms | — |
| **Total NCCL Time** | **1984.540 ms** | **1047.106 ms** | **-937.435 ms** | **-47.24%** |

### End-to-End Training Performance

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Per-step latency | ~3600 ms | ~2974 ms | -17.4% |
| 500 iterations wall time | 28:44 (3.25s/it) | 22:41 (2.43s/it) | **+21%** |
| micro_batch_size | 32 | 30 | -6.25% |

> Although memory pressure reduces micro_batch_size from 32 to 30, the 21% throughput improvement more than compensates for the 6.25% batch size reduction.

## Parameter Lifecycle (ZeRO-2 Mode)

| Phase | Before | After (this PR) |
|-------|--------|-----------------|
| Pre-forward | SHARDED → all-gather → UNSHARDED | SHARDED → all-gather → UNSHARDED |
| Backward (recomputation) | reshard then all-gather again (×144) | **Stays UNSHARDED, no all-gather** |
| Post-backward | SHARDED (post_backward reshard) | UNSHARDED |
| Post optimizer.step | — | **Manual reshard → SHARDED** |
| Next forward | all-gather (fresh weights) | all-gather (fresh weights) ✓ |

## Trade-offs

- **Increased memory**: Parameters remain unsharded throughout backward, requiring micro_batch_size reduction from 32 to 30
- **Manual reshard overhead**: Iterates 74 FSDP units for state transition (no communication, only releases unsharded buffer) — negligible cost
- **Net benefit**: 21% throughput gain far outweighs the 6.25% batch size reduction

## Test Plan

- [x] 500-iteration run confirms normal loss convergence
- [x] Profiler confirms AllGather reduced from 292 to 148 per step
- [x] End-to-end training throughput improved by 21%
- [x] GradNorm is non-zero and reasonable, training is stable




