### PR TITLE
Enable XPU inference for LingBot-VLA (backend-safe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ cd lingbot-vla
 bash install.sh
 ```
 
+> **Hardware support**
+>
+> LingBot-VLA runs on **NVIDIA CUDA, Intel GPUs (XPU), or CPU**. The deployment and evaluation scripts automatically select the available device in this order: CUDA, XPU, then CPU. No code or configuration changes are needed.
+>
+> **Intel GPU (XPU):** install a PyTorch build with XPU support instead of the CUDA wheels:
+>
+> ```bash
+> pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+> ```
+>
+> Skip the `flash-attn` step in `install.sh`. It is CUDA-only and is not required on XPU; the model automatically falls back to PyTorch's built-in `eager` attention on XPU and CPU.
+>
+> Outputs closely match the CUDA and CPU paths. Minor float32 flow-matching rounding drift is expected and is not a bug. `--use_compile` is validated on CUDA; on XPU, prefer running without `--use_compile`.
+
 ---
 
 ## 📦 Model Download

--- a/deploy/lingbot_vla_policy.py
+++ b/deploy/lingbot_vla_policy.py
@@ -52,7 +52,7 @@ class PolicyPreprocessMixin:
         self, observation: dict[str, Tensor], use_bf16: bool = False, noise: Tensor | None = None, num_denoising_step : int = 10
     ):
         self.eval()
-        device = 'cuda'
+        device = next(self.parameters()).device.type
         if use_bf16:
             dtype = torch.bfloat16
         else:
@@ -201,7 +201,13 @@ class LingbotVLAServer:
                 for key in f.keys():
                     merged_weights[key] = f.get_tensor(key)
         policy.load_state_dict(merged_weights, strict=True)
-        policy.cuda()
+        # Device selection: preserve CUDA behavior, enable XPU, fall back to CPU.
+        if torch.cuda.is_available():
+            policy.to("cuda")
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            policy.to("xpu")
+        else:
+            policy.to("cpu")
         
         if self.use_compile:
             policy.model.qwenvl_with_expert = torch.compile(policy.model.qwenvl_with_expert)

--- a/lingbotvla/models/vla/pi0/modeling_lingbot_vla.py
+++ b/lingbotvla/models/vla/pi0/modeling_lingbot_vla.py
@@ -24,13 +24,22 @@ from transformers.modeling_outputs import (
     CausalLMOutputWithPast,
 )
 from transformers.modeling_utils import PreTrainedModel, ALL_ATTENTION_FUNCTIONS
+try:
+    from transformers.utils import LossKwargs
+except ImportError:
+    from typing import TypedDict
+    class LossKwargs(TypedDict, total=False):
+        pass
+    import transformers.utils
+    transformers.utils.LossKwargs = LossKwargs
+# LossKwargs compat
 from transformers.utils import (
     ModelOutput,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     logging,
     replace_return_docstrings,
-    LossKwargs,
+    LossKwargs,  # type: ignore
     can_return_tuple,
     is_torch_flex_attn_available,
 )
@@ -1097,13 +1106,19 @@ class QwenvlWithExpertModel(PreTrainedModel):
         if self.config.vocab_size != 0 and self.config.vocab_size != 257152 and vlm_config.vocab_size != self.config.vocab_size:
             vlm_config.vocab_size = self.config.vocab_size
         
-        vlm_config._attn_implementation = 'flash_attention_2'
-        self.qwenvl = Qwen2_5_VLForConditionalGeneration._from_config(vlm_config, use_flash_attention_2=True)
+        # Attention backend: flash_attention_2 on CUDA (if installed), eager on XPU/CPU.
+        try:
+            from transformers.utils import is_flash_attn_2_available
+            _attn_impl = 'flash_attention_2' if is_flash_attn_2_available() else 'eager'
+        except Exception:
+            _attn_impl = 'eager'
+        vlm_config._attn_implementation = _attn_impl
+        self.qwenvl = Qwen2_5_VLForConditionalGeneration._from_config(vlm_config, attn_implementation=_attn_impl)
         if self.config.use_lm_head:
             self.qwenvl.tie_weights()
         self.config.qwen_expert_config.norm_qkv = self.config.norm_qkv
-        self.config.qwen_expert_config._attn_implementation = 'flash_attention_2'
-        self.qwen_expert = Qwen2ForCausalLM._from_config(self.config.qwen_expert_config, use_flash_attention_2=True, eval=eval)
+        self.config.qwen_expert_config._attn_implementation = _attn_impl
+        self.qwen_expert = Qwen2ForCausalLM._from_config(self.config.qwen_expert_config, eval=eval)
 
         self.rotary_pos_emb = None
         self.window_index = None

--- a/lingbotvla/models/vla/pi0/modeling_pi0.py
+++ b/lingbotvla/models/vla/pi0/modeling_pi0.py
@@ -27,6 +27,15 @@ from transformers.modeling_outputs import (
     TokenClassifierOutput,
 )
 from transformers.modeling_utils import PreTrainedModel, ALL_ATTENTION_FUNCTIONS
+try:
+    from transformers.utils import LossKwargs
+except ImportError:
+    from typing import TypedDict
+    class LossKwargs(TypedDict, total=False):
+        pass
+    import transformers.utils
+    transformers.utils.LossKwargs = LossKwargs
+# LossKwargs compat
 from transformers.utils import (
     ModelOutput,
     add_start_docstrings,
@@ -34,7 +43,7 @@ from transformers.utils import (
     is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
-    LossKwargs,
+    LossKwargs,  # type: ignore
     can_return_tuple,
     is_torch_flex_attn_available,
 )

--- a/lingbotvla/models/vla/pi0/qwenvl_in_vla.py
+++ b/lingbotvla/models/vla/pi0/qwenvl_in_vla.py
@@ -246,6 +246,12 @@ def apply_rotary_pos_emb_vision(
     return q_embed, k_embed
 
 
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
 QWEN2_5_VL_VISION_ATTENTION_CLASSES = {
     "eager": Qwen2_5_VLVisionAttention,
     "flash_attention_2": Qwen2_5_VLVisionFlashAttention2,


### PR DESCRIPTION
## Summary
Enables running LingBot-VLA inference on Intel XPU.

## Changes
- **deploy/lingbot_vla_policy.py**
  - Replace hard-coded `device = 'cuda'` with runtime detection (`next(self.parameters()).device.type`) so inputs follow the model's device.
  - Select the compute device at load time: CUDA if available, else XPU, else CPU.
- **lingbotvla/models/vla/pi0/modeling_lingbot_vla.py**
  - Choose the attention backend dynamically: `flash_attention_2` when `is_flash_attn_2_available()` (CUDA), otherwise `eager`.
  - Add a `LossKwargs` import shim for transformers versions where it moved.
- **lingbotvla/models/vla/pi0/modeling_pi0.py**
  - Same `LossKwargs` import shim.
- **lingbotvla/models/vla/pi0/qwenvl_in_vla.py**
  - Add the standard `rotate_half` helper (previously only available via flash-attn-gated imports, but called unconditionally in the rotary path).

## Compatibility
- CUDA: unchanged
- XPU: newly supported

## Testing
- `python -m py_compile` on all changed files.
- Inference smoke test on Intel XPU.
