### PR TITLE
fix: add lerobot==0.4.2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ msgpack
 websockets
 matplotlib
 numpydantic
+lerobot==0.4.2


### PR DESCRIPTION
## 问题
requirements.txt 未列出 lerobot 依赖，但代码多处从 lerobot 导入。lerobot 0.6.0 同时移除了旧API（lerobot.datasets.lerobot_dataset）和 v3.0 API（lerobot.common.datasets.lerobot_dataset），导致导入失败。

## 解决方案
锁定 lerobot==0.4.2，该版本兼容代码中的两种导入路径。

## 验证
pip install -r requirements.txt
python -c "from lerobot.common.datasets.lerobot_dataset import LeRobotDataset"
